### PR TITLE
Add mappings and readme

### DIFF
--- a/design/mappings/README.md
+++ b/design/mappings/README.md
@@ -1,0 +1,17 @@
+## Docs
+* API client [documentation](https://dandi.readthedocs.io/en/latest/modref/index.html)
+* Raw [schema definitions](https://github.com/dandi/schema/tree/master/releases)
+* [DataCite CVs](https://schema.datacite.org/meta/kernel-4.0/doc/DataCite-MetadataKernel_v4.0.pdf)
+    - see Appendices in link or context in dandi's raw schema
+* Schema viewer links of latest (0.6.2 at the time of writing) are available here:
+    - [dandiset](https://json-schema.app/view/%23?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdandi%2Fschema%2Fmaster%2Freleases%2F0.6.2%2Fdandiset.json)
+    - [asset](https://json-schema.app/view/%23?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdandi%2Fschema%2Fmaster%2Freleases%2F0.6.2%2Fasset.json)
+
+## How to read mappings:
+* Root level keys correspond to ingest schema (CSV files for specimen, file manifest and project invnetory)
+    - keys correspond to columns in csvs
+    - values correspond to path of keys in dandi schema
+    - The `relations` key denotes a relation between objects
+* Path prefix of `asset` corresponds to the asset level metadata for a given dandiset
+* Path prefix of `dandiset` corresponds to the dandiset level metadata for a given dandiset
+

--- a/design/mappings/file_manifest_mappings.yml
+++ b/design/mappings/file_manifest_mappings.yml
@@ -3,14 +3,14 @@ fileManifest:
   Filetype: [
     asset.path, #Split and get file extension
     asset.encodingFormat, #Follows application/<filetype> format but type is just string
-    dandiset.metadata.assetsSummary.dataStandard # has RRID + standard name but is at data collection level
+    dandiset.assetsSummary.dataStandard # has RRID + standard name but is at data collection level
   ]
   Sample ID: asset.path #Split to remove id from filename
   Project: [
     asset.wasGeneratedBy, #schemaKey=Project Not as reliable
-    dandiset.metadata.wasGeneratedBy, #schemaKey=Project More reliable
+    dandiset.wasGeneratedBy, #schemaKey=Project More reliable
   ]
-  Data Collection: dandiset.metadata.name
+  Data Collection: dandiset.name
   R24 ID: asset.id
   File URI: asset.contentUrl
   Checksum: asset.digest # Multiple available see https://github.com/dandi/schema/blob/master/releases/0.6.2/context.json

--- a/design/mappings/file_manifest_mappings.yml
+++ b/design/mappings/file_manifest_mappings.yml
@@ -3,7 +3,6 @@ fileManifest:
   Filetype: [
     asset.path, #Split and get file extension
     asset.encodingFormat, #Follows application/<filetype> format but type is just string
-    dandiset.assetsSummary.dataStandard # has RRID + standard name but is at data collection level
   ]
   Sample ID: asset.path #Split to remove id from filename
   Project: [

--- a/design/mappings/file_manifest_mappings.yml
+++ b/design/mappings/file_manifest_mappings.yml
@@ -1,0 +1,16 @@
+fileManifest:
+  Filename: asset.path
+  Filetype: [
+    asset.path, #Split and get file extension
+    asset.encodingFormat, #Follows application/<filetype> format but type is just string
+    dandiset.metadata.assetsSummary.dataStandard # has RRID + standard name but is at data collection level
+  ]
+  Sample ID: asset.path #Split to remove id from filename
+  Project: [
+    asset.wasGeneratedBy, #schemaKey=Project Not as reliable
+    dandiset.metadata.wasGeneratedBy, #schemaKey=Project More reliable
+  ]
+  Data Collection: dandiset.metadata.name
+  R24 ID: asset.id
+  File URI: asset.contentUrl
+  Checksum: asset.digest # Multiple available see https://github.com/dandi/schema/blob/master/releases/0.6.2/context.json

--- a/design/mappings/project_inventory_mappings.yml
+++ b/design/mappings/project_inventory_mappings.yml
@@ -1,0 +1,120 @@
+project:
+  name: dandiset.metadata.wasGeneratedBy.name
+  title: dandiset.metadata.wasGeneratedBy.name
+  short title: ""
+  description: dandiset.metadata.wasGeneratedBy.description
+  citation: dandiset.metadata.citation #Required
+  # Citations are linked to data collection
+  relations:
+    is part of:
+      subprogram: 
+    has information resource:
+      Web resource:
+    is funded by: 
+      grant: dandiset.metadata.contributor.awardNumber
+      # awardNumber linked to data collection and multiple are listed
+      # roleName=dcite:Funder used to distinguish funding organization vs contributing person
+    has use of results limited by: 
+      license: dandiset.metadata.license
+    has methodology specification: 
+      protocol: dandiset.metadata.protocol #protocol.io links
+    has output:
+      collection: ""
+    has contact person: 
+      person: dandiset.metadata.contributor #Required
+      # roleName=dcite:contactPerson identifies POC
+    has contributor: 
+      person: dandiset.metadata.contributor #Required
+      # rolename=dcite:Author
+    has creator: 
+      person: ""
+    is subject of publication: 
+      dandiset.metadata.relatedResource
+      # relation=dcite:IsPublishedIn
+    collected samples of type:
+      specimen type:
+    involves data of type:
+      modality:
+    has output:
+      collection: 
+collection:
+  name: dandiset.metadata.name #Required
+  title: dandiset.metadata.name #Required
+  short title: ""
+  description: dandiset.metadata.description #Required
+  last updated: dandiset.metadata.dateModified
+  completion state: dandiset.metadata.version #Required
+  access control: dandiset.metadata.access.status
+    #dcite:OpenAccess or dcite:EmbargoedAccess
+  relations:
+    is subject of resource:
+      web resource: dandiset.metadata.url #Permalink
+    has samples of type:
+      specimen type: #TODO
+    is data of type:
+      modality: dandiset.metadata.assetsSummary.approach
+      # name and uri if included
+    was collected using:
+      technique: dandiset.metadata.assetsSummary.measurementTechnique
+      # name and uri if included
+organization:
+  name: dandiset.metadata.contributor.name
+  # schemKey:Organization
+license:
+  name: dandiset.metadata.license 
+  #values: [spdx:CC0-1.0, spdx:CC-BY-4.0]
+  title:
+subprogram:
+  name: dandiset.metadata.contributor.affiliation.name
+  # This is a stretch - not commonly populated
+  title:
+  short title:
+  description:
+  citation:
+  DOI: dandiset.metadata.contributor.affiliation.identifier
+program:
+  name: dandiset.metadata.contributor.affiliation.name
+  # This is a stretch - not commonly populated
+  title:
+  short title:
+  description:
+  citation:
+  DOI: dandiset.metadata.contributor.affiliation.identifier
+
+# Collated from data collections/assets
+grant:
+  name: 
+  title:
+  identifier:
+  report:
+web resource:
+  name:
+  title:
+  short title:
+  url:
+web resource type:
+  name:
+protocol:
+  name:
+  title:
+  short title:
+person:
+  #dandiset.metadata.contributor schemaKey: Person
+  name: dandiset.metadata.contributor.name #Required
+  # Names are in format: familyname, given name(s)
+  given name: dandiset.metadata.contributor.name
+  family name: dandiset.metadata.contributor.name
+  orcid: dandiset.metadata.contributor.identifier
+specimen type:
+  name:
+modality:
+  name: dandiset.metadata.assetsSummary.approach # name and uri if included
+access control:
+  name: dandiset.metadata.access.status
+  #values: [dcite:OpenAccess,dcite:EmbargoedAccess]
+completion state:
+  name: dandiset.metadata.version
+species:
+  name: dandiset.metadata.assetsSummary.species # name and uri if included
+technique:
+  name: dandiset.metadata.assetsSummary.measurementTechnique # name and uri if included

--- a/design/mappings/project_inventory_mappings.yml
+++ b/design/mappings/project_inventory_mappings.yml
@@ -1,9 +1,9 @@
 project:
-  name: dandiset.metadata.wasGeneratedBy.name
-  title: dandiset.metadata.wasGeneratedBy.name
+  name: dandiset.wasGeneratedBy.name
+  title: dandiset.wasGeneratedBy.name
   short title: ""
-  description: dandiset.metadata.wasGeneratedBy.description
-  citation: dandiset.metadata.citation #Required
+  description: dandiset.wasGeneratedBy.description
+  citation: dandiset.citation #Required
   # Citations are linked to data collection
   relations:
     is part of:
@@ -11,25 +11,25 @@ project:
     has information resource:
       Web resource:
     is funded by: 
-      grant: dandiset.metadata.contributor.awardNumber
+      grant: dandiset.contributor.awardNumber
       # awardNumber linked to data collection and multiple are listed
       # roleName=dcite:Funder used to distinguish funding organization vs contributing person
     has use of results limited by: 
-      license: dandiset.metadata.license
+      license: dandiset.license
     has methodology specification: 
-      protocol: dandiset.metadata.protocol #protocol.io links
+      protocol: dandiset.protocol #protocol.io links
     has output:
       collection: ""
     has contact person: 
-      person: dandiset.metadata.contributor #Required
+      person: dandiset.contributor #Required
       # roleName=dcite:contactPerson identifies POC
     has contributor: 
-      person: dandiset.metadata.contributor #Required
+      person: dandiset.contributor #Required
       # rolename=dcite:Author
     has creator: 
       person: ""
     is subject of publication: 
-      dandiset.metadata.relatedResource
+      dandiset.relatedResource
       # relation=dcite:IsPublishedIn
     collected samples of type:
       specimen type:
@@ -38,48 +38,48 @@ project:
     has output:
       collection: 
 collection:
-  name: dandiset.metadata.name #Required
-  title: dandiset.metadata.name #Required
+  name: dandiset.name #Required
+  title: dandiset.name #Required
   short title: ""
-  description: dandiset.metadata.description #Required
-  last updated: dandiset.metadata.dateModified
-  completion state: dandiset.metadata.version #Required
-  access control: dandiset.metadata.access.status
+  description: dandiset.description #Required
+  last updated: dandiset.dateModified
+  completion state: dandiset.version #Required
+  access control: dandiset.access.status
     #dcite:OpenAccess or dcite:EmbargoedAccess
   relations:
     is subject of resource:
-      web resource: dandiset.metadata.url #Permalink
+      web resource: dandiset.url #Permalink
     has samples of type:
       specimen type: #TODO
     is data of type:
-      modality: dandiset.metadata.assetsSummary.approach
+      modality: dandiset.assetsSummary.approach
       # name and uri if included
     was collected using:
-      technique: dandiset.metadata.assetsSummary.measurementTechnique
+      technique: dandiset.assetsSummary.measurementTechnique
       # name and uri if included
 organization:
-  name: dandiset.metadata.contributor.name
+  name: dandiset.contributor.name
   # schemKey:Organization
 license:
-  name: dandiset.metadata.license 
+  name: dandiset.license 
   #values: [spdx:CC0-1.0, spdx:CC-BY-4.0]
   title:
 subprogram:
-  name: dandiset.metadata.contributor.affiliation.name
+  name: dandiset.contributor.affiliation.name
   # This is a stretch - not commonly populated
   title:
   short title:
   description:
   citation:
-  DOI: dandiset.metadata.contributor.affiliation.identifier
+  DOI: dandiset.contributor.affiliation.identifier
 program:
-  name: dandiset.metadata.contributor.affiliation.name
+  name: dandiset.contributor.affiliation.name
   # This is a stretch - not commonly populated
   title:
   short title:
   description:
   citation:
-  DOI: dandiset.metadata.contributor.affiliation.identifier
+  DOI: dandiset.contributor.affiliation.identifier
 
 # Collated from data collections/assets
 grant:
@@ -99,22 +99,22 @@ protocol:
   title:
   short title:
 person:
-  #dandiset.metadata.contributor schemaKey: Person
-  name: dandiset.metadata.contributor.name #Required
+  #dandiset.contributor schemaKey: Person
+  name: dandiset.contributor.name #Required
   # Names are in format: familyname, given name(s)
-  given name: dandiset.metadata.contributor.name
-  family name: dandiset.metadata.contributor.name
-  orcid: dandiset.metadata.contributor.identifier
+  given name: dandiset.contributor.name
+  family name: dandiset.contributor.name
+  orcid: dandiset.contributor.identifier
 specimen type:
   name:
 modality:
-  name: dandiset.metadata.assetsSummary.approach # name and uri if included
+  name: dandiset.assetsSummary.approach # name and uri if included
 access control:
-  name: dandiset.metadata.access.status
+  name: dandiset.access.status
   #values: [dcite:OpenAccess,dcite:EmbargoedAccess]
 completion state:
-  name: dandiset.metadata.version
+  name: dandiset.version
 species:
-  name: dandiset.metadata.assetsSummary.species # name and uri if included
+  name: dandiset.assetsSummary.species # name and uri if included
 technique:
-  name: dandiset.metadata.assetsSummary.measurementTechnique # name and uri if included
+  name: dandiset.assetsSummary.measurementTechnique # name and uri if included

--- a/design/mappings/project_inventory_mappings.yml
+++ b/design/mappings/project_inventory_mappings.yml
@@ -21,8 +21,7 @@ project:
     has output:
       collection: ""
     has contact person: 
-      person: dandiset.contributor #Required
-      # roleName=dcite:contactPerson identifies POC
+      person: dandiset.wasGeneratedBy.wasAssociatedWith[schemaKey:Person, roleName:dcite:ContactPerson]
     has contributor: 
       person: dandiset.contributor #Required
       # rolename=dcite:Author

--- a/design/mappings/specimen_mappings.yml
+++ b/design/mappings/specimen_mappings.yml
@@ -9,8 +9,8 @@ specimen:
   age: asset.wasAttributedTo.age.value
   sex (cv): asset.wasAttributedTo.sex.name
   genotype: asset.wasAttributedTo.genotype
-  modality  (cv): dandiset.metadata.assetsSummary.approach.name
-  technique  (cv): dandiset.metaddata.assetsSummary.measurementTechnique.name
+  modality  (cv): dandiset.assetsSummary.approach.name
+  technique  (cv): dandiset.assetsSummary.measurementTechnique.name
   anatomical structure (cv): [
     asset.about, # schemakey: Anatomy - Not very reliable
     asset.wasDerivedForm.anatomy, # schemakey: Anatomy - Even less reliable
@@ -19,16 +19,16 @@ specimen:
   total processed subspecimens:
   organization (cv): [
     asset.contributor, # schemaKey: Organization - Not very reliable
-    dandiset.metadata.contributor, # More reliable
+    dandiset.contributor, # More reliable
   ]
   investigator: [
     asset.contributor, #schemaKey: Person - not very reliable
-    dandiset.metadata.contributor, # More reliable
+    dandiset.contributor, # More reliable
   ]
-  grant number (cv): dandiset.metadata.contributor.awardnumber #schemaKey=Organization, roleName=dcite:Funder
-  data collection (cv): dandiset.metadata.name
+  grant number (cv): dandiset.contributor.awardnumber #schemaKey=Organization, roleName=dcite:Funder
+  data collection (cv): dandiset.name
   r24 name (cv): DANDI
-  r24 link: dandiset.metadata.url #Links to datacollection
+  r24 link: dandiset.url #Links to datacollection
   comments: ""
   metadata submission: ""
 

--- a/design/mappings/specimen_mappings.yml
+++ b/design/mappings/specimen_mappings.yml
@@ -1,0 +1,57 @@
+specimen:
+  sample id: asset.path #Required
+  sample type (cv): asset.wasDerivedFrom.sampleType.name
+  species (cv): asset.wasAttributedTo.species.name
+  species ncbi taxonomy id: asset.wasAttributedTo.species.identifier
+  parent specimen id: asset.wasDerivedFrom # See footnote 1
+  parent specimen type (cv): asset.wasDerivedFrom # See footnote 1
+  subject id: asset.wasAttributedTo.identifier #Identifier is required but wasAttributedTo isn't
+  age: asset.wasAttributedTo.age.value
+  sex (cv): asset.wasAttributedTo.sex.name
+  genotype: asset.wasAttributedTo.genotype
+  modality  (cv): dandiset.metadata.assetsSummary.approach.name
+  technique  (cv): dandiset.metaddata.assetsSummary.measurementTechnique.name
+  anatomical structure (cv): [
+    asset.about, # schemakey: Anatomy - Not very reliable
+    asset.wasDerivedForm.anatomy, # schemakey: Anatomy - Even less reliable
+  ]
+  subspecimen type (cv): ""
+  total processed subspecimens:
+  organization (cv): [
+    asset.contributor, # schemaKey: Organization - Not very reliable
+    dandiset.metadata.contributor, # More reliable
+  ]
+  investigator: [
+    asset.contributor, #schemaKey: Person - not very reliable
+    dandiset.metadata.contributor, # More reliable
+  ]
+  grant number (cv): dandiset.metadata.contributor.awardnumber #schemaKey=Organization, roleName=dcite:Funder
+  data collection (cv): dandiset.metadata.name
+  r24 name (cv): DANDI
+  r24 link: dandiset.metadata.url #Links to datacollection
+  comments: ""
+  metadata submission: ""
+
+# Footnotes
+# 1. Parent specimen info is in nested field `asset.wasDerivedFrom`.
+# Heirarchy can be determined from `sampleType` at each level. Example:
+#  "wasDerivedFrom": [
+#         {
+#             "schemaKey": "BioSample",
+#             "identifier": "20180313_sample_3",
+#             "sampleType": {
+#                 "name": "cell",
+#                 "schemaKey": "SampleType"
+#             },
+#             "wasDerivedFrom": [
+#                 {
+#                     "schemaKey": "BioSample",
+#                     "identifier": "20180313_slice_3",
+#                     "sampleType": {
+#                         "name": "slice",
+#                         "schemaKey": "SampleType"
+#                     }
+#                 }
+#             ]
+#         }
+#     ],


### PR DESCRIPTION
This PR adds:

Mappings between the following objects and the dandi metadata schema:
- Specimen inventory
- Project inventory
- File manifest